### PR TITLE
create initial project issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/project.md
+++ b/.github/ISSUE_TEMPLATE/project.md
@@ -1,0 +1,18 @@
+---
+name: Project Proposal issue
+about: Use this template for creating project proposals
+title: "[DATE]: [PROJECT NAME]"
+labels: project, needs triage
+---
+
+### Problem
+
+describe the problem which the project should tackle
+
+### Goals
+
+describe the state of the world after the project has been completed
+
+### Non Goals / Out of Scope
+
+- describe some problems / work which will explicitly not be tackled in the scope of this project


### PR DESCRIPTION
The web-based issue template creation tools are broken, so would like to get this initial template checked in to see if I can get those tools working again.