### PR TITLE
Remove setup-node step from prettier lints

### DIFF
--- a/.github/workflows/prettier-lint.yml
+++ b/.github/workflows/prettier-lint.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
       - name: Install dependencies
         run: npm install prettier -g
       - name: Run prettier

--- a/workflow-templates/prettier-lint.yml
+++ b/workflow-templates/prettier-lint.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
       - name: Install dependencies
         run: npm install prettier -g
       - name: Run prettier


### PR DESCRIPTION
That step shouldn't be necessary -- the runner image already includes node 18.18.2.

---
Mirrors comcode-org/hackmudclient#49